### PR TITLE
Update Deployment: Clipper -> Ray Serve

### DIFF
--- a/course-content/testing-and-deployment/web-deployment.md
+++ b/course-content/testing-and-deployment/web-deployment.md
@@ -14,5 +14,5 @@ description: How to deploy your models to the web?
   * You can deploy the code as a “server-less function.”
   * You can deploy the code via a model serving solution.
 * If you are making **CPU inference**, you can get away with scaling by launching more servers \(Docker\), or going serverless \(AWS Lambda\).
-* If you are using **GPU inference**, things like TF Serving and Clipper become useful with features such as adaptive batching.
+* If you are using **GPU inference**, things like TF Serving and [Ray Serve](https://docs.ray.io/en/latest/serve/index.html#rayserve) become useful with features such as adaptive batching.
 


### PR DESCRIPTION
Hi there! 

Thanks for creating this great content. I'm the maintainer of Clipper. Clipper is currently no longer maintained. The codebase is essentially "archived for research comparison" and I would no longer recommend people to deploy up-to-date models with it. I updated the link to reflect the next iteration of Clipper project, built on Ray: Ray Serve. 